### PR TITLE
Added DisplayViewController and restructured existing to change views

### DIFF
--- a/Loot.xcodeproj/project.pbxproj
+++ b/Loot.xcodeproj/project.pbxproj
@@ -8,9 +8,11 @@
 
 /* Begin PBXBuildFile section */
 		0F0F37D62B8BCDE60018B090 /* LootApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F0F37D52B8BCDE60018B090 /* LootApp.swift */; };
-		0F0F37D82B8BCDE60018B090 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F0F37D72B8BCDE60018B090 /* ContentView.swift */; };
 		0F0F37DA2B8BCDE80018B090 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 0F0F37D92B8BCDE80018B090 /* Assets.xcassets */; };
 		0F0F37DD2B8BCDE80018B090 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 0F0F37DC2B8BCDE80018B090 /* Preview Assets.xcassets */; };
+		6F566CFE2B9F609A00EC7C3D /* DisplayViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F566CFD2B9F609A00EC7C3D /* DisplayViewController.swift */; };
+		6F566D002B9F624100EC7C3D /* DisplayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F566CFF2B9F624100EC7C3D /* DisplayView.swift */; };
+		6F566D022B9F676C00EC7C3D /* GameView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F566D012B9F676C00EC7C3D /* GameView.swift */; };
 		6FA3BFBE2B8FB92A005A6846 /* HomeMenuView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FA3BFBD2B8FB92A005A6846 /* HomeMenuView.swift */; };
 		6FA3BFC02B8FC825005A6846 /* GameLobbyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FA3BFBF2B8FC825005A6846 /* GameLobbyView.swift */; };
 /* End PBXBuildFile section */
@@ -18,9 +20,11 @@
 /* Begin PBXFileReference section */
 		0F0F37D22B8BCDE60018B090 /* Loot.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Loot.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		0F0F37D52B8BCDE60018B090 /* LootApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LootApp.swift; sourceTree = "<group>"; };
-		0F0F37D72B8BCDE60018B090 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		0F0F37D92B8BCDE80018B090 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		0F0F37DC2B8BCDE80018B090 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
+		6F566CFD2B9F609A00EC7C3D /* DisplayViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisplayViewController.swift; sourceTree = "<group>"; };
+		6F566CFF2B9F624100EC7C3D /* DisplayView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisplayView.swift; sourceTree = "<group>"; };
+		6F566D012B9F676C00EC7C3D /* GameView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameView.swift; sourceTree = "<group>"; };
 		6FA3BFBD2B8FB92A005A6846 /* HomeMenuView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeMenuView.swift; sourceTree = "<group>"; };
 		6FA3BFBF2B8FC825005A6846 /* GameLobbyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameLobbyView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -56,11 +60,13 @@
 			isa = PBXGroup;
 			children = (
 				0F0F37D52B8BCDE60018B090 /* LootApp.swift */,
-				0F0F37D72B8BCDE60018B090 /* ContentView.swift */,
-				0F0F37D92B8BCDE80018B090 /* Assets.xcassets */,
-				0F0F37DB2B8BCDE80018B090 /* Preview Content */,
 				6FA3BFBD2B8FB92A005A6846 /* HomeMenuView.swift */,
 				6FA3BFBF2B8FC825005A6846 /* GameLobbyView.swift */,
+				6F566D012B9F676C00EC7C3D /* GameView.swift */,
+				0F0F37D92B8BCDE80018B090 /* Assets.xcassets */,
+				0F0F37DB2B8BCDE80018B090 /* Preview Content */,
+				6F566CFD2B9F609A00EC7C3D /* DisplayViewController.swift */,
+				6F566CFF2B9F624100EC7C3D /* DisplayView.swift */,
 			);
 			path = Loot;
 			sourceTree = "<group>";
@@ -175,9 +181,11 @@
 			buildActionMask = 2147483647;
 			files = (
 				6FA3BFC02B8FC825005A6846 /* GameLobbyView.swift in Sources */,
-				0F0F37D82B8BCDE60018B090 /* ContentView.swift in Sources */,
+				6F566CFE2B9F609A00EC7C3D /* DisplayViewController.swift in Sources */,
+				6F566D002B9F624100EC7C3D /* DisplayView.swift in Sources */,
 				0F0F37D62B8BCDE60018B090 /* LootApp.swift in Sources */,
 				6FA3BFBE2B8FB92A005A6846 /* HomeMenuView.swift in Sources */,
+				6F566D022B9F676C00EC7C3D /* GameView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Loot/DisplayView.swift
+++ b/Loot/DisplayView.swift
@@ -1,0 +1,15 @@
+//
+//  DisplayView.swift
+//  Loot
+//
+//  Created by Kenna Chase on 3/11/24.
+//
+
+import Foundation
+
+enum DisplayView {
+    case startNewGameView
+    case homeMenuView
+    case gameLobbyView
+    case gameView
+}

--- a/Loot/DisplayViewController.swift
+++ b/Loot/DisplayViewController.swift
@@ -1,0 +1,32 @@
+//
+//  ViewDisplayController.swift
+//  Loot
+//
+//  Created by Kenna Chase on 3/11/24.
+//
+
+import Foundation
+
+class DisplayViewController: ObservableObject {
+
+    /**
+     A common, shared instance of the View Display Controller that is available globally throughout the app.
+     */
+    public static let sharedViewDisplayController = DisplayViewController()
+
+    /** Published means there will be change notifications, so changes are automatically sent out to observers
+     */
+    @Published var currentView: DisplayView = .startNewGameView
+
+    @Published var previousView: DisplayView = .startNewGameView
+
+    func changeView(view: DisplayView) {
+        // check if in current view
+        if view == currentView {
+            return
+        }
+
+        previousView = currentView
+        currentView = view
+    }
+}

--- a/Loot/GameLobbyView.swift
+++ b/Loot/GameLobbyView.swift
@@ -6,13 +6,14 @@
 import SwiftUI
 
 struct GameLobbyView: View {
+    @ObservedObject var displayViewController = DisplayViewController.sharedViewDisplayController
 
     var body: some View {
 
         HStack {
             Spacer()
 
-            Text("Game Lobby")
+            Text("Game Room Key: XXX-XXX")
                     .font(.largeTitle)
                     .foregroundColor(.black)
                     .bold()
@@ -21,8 +22,19 @@ struct GameLobbyView: View {
        }
 
         VStack {
-            Text("Messages: .....")
-            // TODO: Add websocket text component to display recieved websocket information 
+            Button {
+                displayViewController.changeView(view: .gameView)
+            } label: {
+                Text("Temp Button: Start Game")
+                    .foregroundColor(.black)
+                    .font(.title2)
+                    .bold()
+            }
+            .background(
+                Capsule(style: .continuous)
+                .fill(.gray)
+                .frame(width: 250, height: 50)
+            )
 
         }.padding()
 

--- a/Loot/GameView.swift
+++ b/Loot/GameView.swift
@@ -1,14 +1,15 @@
 //
-//  ContentView.swift
+//  GameView.swift
 //  Loot
 //
-//  Created by Benjamin Michael on 2/25/24.
+//  Created by Kenna Chase on 3/11/24.
 //
 
 import SwiftUI
 
-struct ContentView: View {
+struct GameView: View {
     var body: some View {
+        Text("Game View")
         VStack {
             Image(systemName: "globe")
                 .imageScale(.large)
@@ -20,5 +21,5 @@ struct ContentView: View {
 }
 
 #Preview {
-    ContentView()
+    GameView()
 }

--- a/Loot/HomeMenuView.swift
+++ b/Loot/HomeMenuView.swift
@@ -8,6 +8,8 @@
 import SwiftUI
 
 struct HomeMenuView: View {
+    @ObservedObject var displayViewController = DisplayViewController.sharedViewDisplayController
+
     @State private var gameRoomKey: String = ""
 
     var body: some View {
@@ -70,10 +72,12 @@ struct HomeMenuView: View {
         print("\nAuthenticating ... ")
         // Validate Game Logic
         print("Joining game ...." + gameKey)
+        displayViewController.changeView(view: .gameLobbyView)
     }
 
     func createGame() -> String {
         print("\nCreating game .....")
+        displayViewController.changeView(view: .tus)
         return "FAKE_GAME_CODE"
     }
 }

--- a/Loot/HomeMenuView.swift
+++ b/Loot/HomeMenuView.swift
@@ -77,7 +77,7 @@ struct HomeMenuView: View {
 
     func createGame() -> String {
         print("\nCreating game .....")
-        displayViewController.changeView(view: .tus)
+        displayViewController.changeView(view: .gameLobbyView)
         return "FAKE_GAME_CODE"
     }
 }

--- a/Loot/LootApp.swift
+++ b/Loot/LootApp.swift
@@ -9,9 +9,20 @@ import SwiftUI
 
 @main
 struct LootApp: App {
+    @ObservedObject var displayViewController = DisplayViewController.sharedViewDisplayController
+
     var body: some Scene {
         WindowGroup {
-            ContentView()
+            switch displayViewController.currentView {
+            case .gameLobbyView:
+                GameLobbyView()
+            case .homeMenuView:
+                HomeMenuView()
+            case .gameView:
+                GameView()
+            case .startNewGameView:
+                HomeMenuView()
+            }
         }
     }
 }


### PR DESCRIPTION
**Changes:** 
- Added DisplayView and DisplayViewController to implement structure for changing views
- Restructured the HomeMenuView and GameLobbyView to change to a different view when the buttons are pressed 
- Implemented the change view case statement logic in the LootApp file
-  ***Removed*** the unnecessary ContentView file as the views are changed in the LootApp file
- Added a temporary placeholder for the GameView to add/test the transition from the lobby to the game

**Testing:** 
- Successfully saw changes in the displayed view multiple times by pressing the associated buttons that called the change view function

Notes for future implementations: 
- New Views will need to be added to the enum in DisplayView
- New Views will also need  `@ObservedObject var displayViewController = DisplayViewController.sharedViewDisplayController` to change views
-  Views are changed with the following function: `displayViewController.changeView(view: .gameLobbyView)
`
