### PR TITLE
Response object changes

### DIFF
--- a/Loot/Networking/Requests/Player.swift
+++ b/Loot/Networking/Requests/Player.swift
@@ -27,7 +27,7 @@ struct Player: Codable {
     let id: UUID
     let name: String
     let ready: Bool
-    var isSafe: Bool
-    var isOut: Bool
+    let isSafe: Bool
+    let isOut: Bool
     let isHost: Bool
 }

--- a/Loot/Networking/Responses/RoundStatusResponse.swift
+++ b/Loot/Networking/Responses/RoundStatusResponse.swift
@@ -11,4 +11,5 @@ struct RoundStatusResponse: Codable {
     let winner: Player
     let gameOver: Bool
     let roundOver: Bool
+    let winningCard: CardResponse?
 }

--- a/Loot/Networking/Responses/StartRoundResponse.swift
+++ b/Loot/Networking/Responses/StartRoundResponse.swift
@@ -9,6 +9,7 @@ import Foundation
 
 struct StartRoundResponse: Codable {
     let playersAndCards: [PlayerCardPair]
+    let cardKeptOut: CardResponse
 }
 
 struct PlayerCardPair: Codable {

--- a/LootTests/ObjectDecodingTests.swift
+++ b/LootTests/ObjectDecodingTests.swift
@@ -58,11 +58,12 @@ final class ObjectDecodingTests: XCTestCase {
 
         stompClient.registerListener("/topic/test/decoding/\(id.uuidString.lowercased())") { data in
             do {
-                let lobbyResponse = try JSONDecoder().decode(LobbyResponse.self, from: data)
+                let lobbyResponse = try JSONDecoder().decode(LobbyResponse?.self, from: data)
                 XCTAssertNotNil(lobbyResponse)
                 responseExpectation.fulfill()
             } catch {
-                XCTFail("Unable to decode the lobby response")
+                let jsonString = String(data: data, encoding: .utf8)
+                XCTFail("Unable to decode the lobby responseL \(jsonString)")
             }
         }
         stompClient.sendData(body: request, to: "/app/test/decoding")


### PR DESCRIPTION
Changed the StartRoundResponse to include the card that has been kept out of the round, and the RoundStatusResponse to include the winning player's card.